### PR TITLE
chore: point renovate.json at next, add main-branch guard

### DIFF
--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -1,0 +1,30 @@
+---
+name: Main Branch Source Guard
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Guard main branch source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify pull request source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [[ "${HEAD_REF}" == "next" || "${HEAD_REF}" == hotfix-* ]]; then
+            echo "Head branch '${HEAD_REF}' is allowed to target main."
+            exit 0
+          fi
+          echo "::error::Pull requests into main must come from 'next' or a 'hotfix-*' branch (got '${HEAD_REF}'). See ADR-0008 (z-shell/.github) for the branching model."
+          exit 1

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,6 @@
     "local>z-shell/.github:renovate-config",
     ":dependencyDashboardApproval",
     ":disableVulnerabilityAlerts"
-  ]
+  ],
+  "baseBranches": ["next"]
 }


### PR DESCRIPTION
Closes #177.

Same root cause found and fixed in z-shell/zsh-eza this session:

- `renovate.json` had no `baseBranches` override, so Renovate defaulted to `main`, bypassing `next` the same way several past PRs (#171, #150-#156) did. `dependabot.yml` was already fixed for this in #172; this brings Renovate in line with it and ADR-0008 (z-shell/.github).
- Adds `.github/workflows/main-branch-guard.yml`: a required-status-check workflow that fails a PR targeting `main` unless its head branch is `next` or matches `hotfix-*`. `next` was found 1 commit behind `main` due to #176 merging directly from a non-`next`/`hotfix-*` branch; already fast-forwarded `next` to resolve that gap.

This PR only adds the check. Wiring it into `main`'s ruleset as a required status check is a follow-up, once the check has run at least once on a real PR against `main`.

## Test plan

- [x] `renovate.json` validated with `python3 -m json.tool`
- [x] Workflow YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`