### PR TITLE
chore(deps): move Renovate config under .github

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,5 @@
     ":dependencyDashboardApproval",
     ":disableVulnerabilityAlerts"
   ],
-  "baseBranches": ["next"]
+  "baseBranchPatterns": ["next"]
 }


### PR DESCRIPTION
## Summary

- move the repository Renovate config to `.github/renovate.json`
- use the current `baseBranchPatterns` option while preserving the `next` target

## Validation

- `jq empty .github/renovate.json`
- semantic comparison with the previous root config
- `git diff --check`

Relates to z-shell/.github#452