### PR TITLE
docs: correct instruction and test guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,11 @@ This project follows the organization-wide [Z-Shell Organization Guidelines](htt
 ## Conventions & Testing
 
 - Language: Zsh and POSIX sh.
-- Follow `.github/instructions/zsh-scripting.instructions.md`.
-- Verify installer and loader behavior with the test suite:
-  ```bash
-  make test || ./tests/run.sh
+- Follow the canonical
+  [shell dialect dispatcher](https://github.com/z-shell/.github/blob/main/.github/instructions/shell.instructions.md)
+  and, for Zsh files, the
+  [Zsh Scripting Standard](https://github.com/z-shell/.github/blob/main/.github/instructions/zsh-scripting.instructions.md).
+- Verify installer and loader behavior with the repository test suite:
+  ```sh
+  sh ./tests/installers.sh
   ```


### PR DESCRIPTION
## Summary

- distinguish the canonical shell dialect dispatcher from the Zsh scripting
  standard
- replace inaccurate generic test guidance with the repository's actual
  installer test command

## Verification

- cross-repository instruction contract: 88 tests passed
- `git diff --check origin/next...HEAD`
