### PR TITLE
ci: adopt configured zsh-lint profile

### DIFF
--- a/.github/workflows/zsh-lint.yml
+++ b/.github/workflows/zsh-lint.yml
@@ -7,11 +7,13 @@ on:
     paths:
       - "public/zsh/init.zsh"
       - ".github/workflows/zsh-lint.yml"
+      - "zsh-lint.json"
   pull_request:
     branches: [next, main]
     paths:
       - "public/zsh/init.zsh"
       - ".github/workflows/zsh-lint.yml"
+      - "zsh-lint.json"
   workflow_dispatch: {}
 
 permissions:
@@ -23,9 +25,35 @@ concurrency:
 
 jobs:
   zsh-lint:
-    name: Zsh Lint
-    uses: z-shell/.github/.github/workflows/zsh-lint.yml@6dca2bef75c60106cde7237db5dea2c2eeed243b
-    with:
-      zsh-lint-ref: 3c4966b454fc07a346772a24d8311adab91414ed
-      paths: |
-        public/zsh/init.zsh
+    name: Configured Zsh Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check out zsh-lint
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/zsh-lint
+          ref: 1e8b0a6c02d4aa433e6aee8ca141e11ef62ba76b
+          path: .zsh-lint-tool
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          go-version: "1.25"
+      - name: Build zsh-lint
+        run: go build -C .zsh-lint-tool -o "$RUNNER_TEMP/zsh-lint" ./cmd/zsh-lint
+      - name: Run configured advisory profile
+        shell: bash
+        env:
+          ZSH_LINT_PATHS: |
+            public/zsh/init.zsh
+        run: |
+          set -euo pipefail
+          mapfile -t targets < <(printf '%s\n' "$ZSH_LINT_PATHS" | sed '/^[[:space:]]*$/d')
+          find -- "${targets[@]}" -type f -print0 | sort -z > "$RUNNER_TEMP/zsh-lint-files"
+          mapfile -d '' files < "$RUNNER_TEMP/zsh-lint-files"
+          "$RUNNER_TEMP/zsh-lint" --config zsh-lint.json "${files[@]}"

--- a/zsh-lint.json
+++ b/zsh-lint.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "project": {
+    "kind": "library",
+    "minimum_zsh": "5.8.1",
+    "function_namespaces": []
+  },
+  "sources": [{ "root": "public/zsh", "profile": "sourced-library" }]
+}


### PR DESCRIPTION
## Summary

- add explicit `z-shell/project@1` metadata for src
- run configured advisory analysis from immutable zsh-lint commit `1e8b0a6c02d4aa433e6aee8ca141e11ef62ba76b`
- retain independent native Zsh checks and require zero configured errors or warnings

## Verification

- `actionlint .github/workflows/zsh-lint.yml`
- configured local analysis completed with zero errors and warnings
- `git diff --check`

Closes #189.
